### PR TITLE
Trace class loading

### DIFF
--- a/compiler/jit/jit_compiler.cc
+++ b/compiler/jit/jit_compiler.cc
@@ -33,6 +33,7 @@
 #include "oat_quick_method_header.h"
 #include "object_lock.h"
 #include "thread_list.h"
+#include "../../runtime/nano_tracing.h"
 
 namespace art {
 namespace jit {
@@ -200,6 +201,7 @@ JitCompiler::~JitCompiler() {
 }
 
 bool JitCompiler::CompileMethod(Thread* self, ArtMethod* method, bool osr) {
+  NANO_TRACE_SCOPE_FROM_STRING(self, "JitCompiler.CompileMethod()");
   DCHECK(!method->IsProxyMethod());
   TimingLogger logger("JIT compiler timing logger", true, VLOG_IS_ON(jit));
   StackHandleScope<2> hs(self);

--- a/runtime/class_linker.cc
+++ b/runtime/class_linker.cc
@@ -76,6 +76,7 @@
 #include "mirror/reference-inl.h"
 #include "mirror/stack_trace_element.h"
 #include "mirror/string-inl.h"
+#include "nano_tracing.h"
 #include "native/dalvik_system_DexFile.h"
 #include "oat.h"
 #include "oat_file.h"
@@ -2467,6 +2468,7 @@ mirror::Class* ClassLinker::DefineClass(Thread* self,
                                         const DexFile& dex_file,
                                         const DexFile::ClassDef& dex_class_def) {
   StackHandleScope<3> hs(self);
+  NANO_TRACE_SCOPE_FROM_STRING_AND_META(self, "Class ClassLinker.DefineClass()", descriptor);
   auto klass = hs.NewHandle<mirror::Class>(nullptr);
 
   // Load the class from the dex file.
@@ -2955,6 +2957,7 @@ void ClassLinker::LoadClass(Thread* self,
                             const DexFile& dex_file,
                             const DexFile::ClassDef& dex_class_def,
                             Handle<mirror::Class> klass) {
+  NANO_TRACE_SCOPE_FROM_STRING(self, "bool ClassLinker.LoadClass()");
   const uint8_t* class_data = dex_file.GetClassData(dex_class_def);
   if (class_data == nullptr) {
     return;  // no fields or methods - for example a marker interface
@@ -3844,6 +3847,7 @@ bool ClassLinker::AttemptSupertypeVerification(Thread* self,
 }
 
 void ClassLinker::VerifyClass(Thread* self, Handle<mirror::Class> klass, LogSeverity log_level) {
+  NANO_TRACE_SCOPE_FROM_STRING(self, "void ClassLinker.VerifyClass()");
   {
     // TODO: assert that the monitor on the Class is held
     ObjectLock<mirror::Class> lock(self, klass);
@@ -4479,6 +4483,8 @@ bool ClassLinker::InitializeClass(Thread* self, Handle<mirror::Class> klass,
     return true;
   }
 
+  NANO_TRACE_SCOPE_FROM_STRING(self, "bool ClassLinker.InitializeClass()");
+
   // Fast fail if initialization requires a full runtime. Not part of the JLS.
   if (!CanWeInitializeClass(klass.Get(), can_init_statics, can_init_parents)) {
     return false;
@@ -5111,8 +5117,8 @@ bool ClassLinker::LinkClass(Thread* self,
                             Handle<mirror::Class> klass,
                             Handle<mirror::ObjectArray<mirror::Class>> interfaces,
                             MutableHandle<mirror::Class>* h_new_class_out) {
+  NANO_TRACE_SCOPE_FROM_STRING(self, "bool ClassLinker.LinkClass()");
   CHECK_EQ(mirror::Class::kStatusLoaded, klass->GetStatus());
-
   if (!LinkSuperClass(klass)) {
     return false;
   }
@@ -5132,7 +5138,6 @@ bool ClassLinker::LinkClass(Thread* self,
   }
   CreateReferenceInstanceOffsets(klass);
   CHECK_EQ(mirror::Class::kStatusLoaded, klass->GetStatus());
-
   ImTable* imt = nullptr;
   if (klass->ShouldHaveImt()) {
     // If there are any new conflicts compared to the super class we can not make a copy. There

--- a/runtime/nano_tracing.h
+++ b/runtime/nano_tracing.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ART_RUNTIME_NANO_TRACING_H_
+#define ART_RUNTIME_NANO_TRACING_H_
+
+#include "thread.h"
+
+#define NANO_TRACE_SCOPE_FROM_STRING(thread_self, name_string) FromStringScopedArtTrace ___nano_tracer(thread_self, reinterpret_cast<const char *>(name_string))
+#define NANO_TRACE_SCOPE_FROM_STRING_AND_META(thread_self, name_string, meta) FromStringAndMetaScopedArtTrace ___nano_tracer(thread_self, reinterpret_cast<const char *>(name_string), reinterpret_cast<const char *>(meta))
+
+class FromStringScopedArtTrace {
+ private:
+  art::Thread* thread;
+
+ public:
+  ALWAYS_INLINE FromStringScopedArtTrace(art::Thread* t, const char* functionName) {
+    thread = t;
+    thread->TraceStart(functionName);
+  }
+
+  ALWAYS_INLINE ~FromStringScopedArtTrace() {
+    thread->TraceEnd();
+  }
+};
+
+class FromStringAndMetaScopedArtTrace {
+ private:
+  art::Thread* thread;
+
+ public:
+  ALWAYS_INLINE FromStringAndMetaScopedArtTrace(art::Thread* t, const char* functionName, const char* meta) {
+    thread = t;
+    thread->TraceStart(functionName, meta);
+  }
+
+  ALWAYS_INLINE ~FromStringAndMetaScopedArtTrace() {
+    thread->TraceEnd();
+  }
+};
+
+#endif  // ART_RUNTIME_NANO_TRACING_H_

--- a/runtime/native/dalvik_system_DexFile.cc
+++ b/runtime/native/dalvik_system_DexFile.cc
@@ -249,6 +249,7 @@ static jboolean DexFile_closeDexFile(JNIEnv* env, jclass, jobject cookie) {
   return all_deleted ? JNI_TRUE : JNI_FALSE;
 }
 
+// Change this?
 static jclass DexFile_defineClassNative(JNIEnv* env,
                                         jclass,
                                         jstring javaName,

--- a/runtime/thread.h
+++ b/runtime/thread.h
@@ -156,6 +156,21 @@ class Thread {
   // Called from the interpreter to log the end of a method.
   ALWAYS_INLINE void TraceEnd(ArtMethod* method);
 
+  // Start a trace by copying string ptr into buffer. Using this method requires
+  // an extra bit to be written into the buffer as a delimiter. However, it is still
+  // significantly faster than atrace since it doesn't copy the entire function name
+  // until later. (see atrace https://android.googlesource.com/platform/system/core/+/2d3150e%5E!/)
+  ALWAYS_INLINE void TraceStart(const char *name);
+  ALWAYS_INLINE void TraceStart(const char *name, const char *metadata);
+
+  // Called from the interpreter to log the start of a method. This version of TraceStart requires
+  // a few less C instructions to execute than the string version. However, it is more cumbersome.
+  // It is left here only as a reminder.
+  ALWAYS_INLINE void TraceStart(int64_t identifier);
+
+  // Called from the interpreter to log the end of a method.
+  ALWAYS_INLINE void TraceEnd();
+
   // Enables tracing on this Thread.
   void StartTracing() SHARED_REQUIRES(Locks::mutator_lock_);
 


### PR DESCRIPTION
Profile methods inside ClassLinker known to be slow as well as a few other methods I am interested in. I made sure to break out the linking/verification/loading/initialize calls since these are main categories of class loading time.

For the DefineClass method, I also include metadata for the class name being loaded. The out.txt file will contain lines that look like 

```
    Class ClassLinker.DefineClass()#Lcom/ubercab/presidio/app/core/root/main/ride/request/confirmation/location/ConfirmationLocationUtils;
```

The tracer will now look like the following

<img width="1177" alt="screen shot 2018-03-02 at 3 11 28 pm" src="https://user-images.githubusercontent.com/549900/36926439-b9974bc0-1e2c-11e8-8e73-4b1ab4f26daa.png">
<img width="852" alt="screen shot 2018-03-02 at 3 11 11 pm" src="https://user-images.githubusercontent.com/549900/36926440-b9abeb84-1e2c-11e8-803e-cb65caddfeba.png">


**Background on Class Loading**
Class loading is comprised of the following steps Loading (get pointer to memory mapped dex file. this step will sometimes require paging into memory), Linking (integrates data structures from loading into runtime), Static Initialization (running static initializers) and Verification (verify correctness of code. sometimes requires going back to dex file so can contain IO).