### PR TITLE
Remove hint that preoritizes blacklisting

### DIFF
--- a/runtime/thread.cc
+++ b/runtime/thread.cc
@@ -179,7 +179,7 @@ void flush_trace_data(std::string out_path, int64_t* trace_data, int64_t* end)
 }
 
 void Thread::TraceStart(ArtMethod* method) {
-  if (UNLIKELY(method->is_trace_enabled)) {  // Only trace if we haven't blacklisted the ArtMethod. Use compiler hint to favor blacklisted method performance.
+  if (method->is_trace_enabled) {  // Only trace if we haven't blacklisted the ArtMethod. We could use compiler hint to favor blacklisted method performance. However, at time of writing blacklisting is infrequently used.
     if (LIKELY(tlsPtr_.trace_data_ptr != nullptr)) {  // Only trace if we're on the correct Thread. Use compiler hint to favor the performance of the traced Thread.
       *tlsPtr_.trace_data_ptr++ = reinterpret_cast<int64_t>(method);
       *tlsPtr_.trace_data_ptr++ = generic_timer_count();
@@ -188,7 +188,7 @@ void Thread::TraceStart(ArtMethod* method) {
 }
 
 void Thread::TraceEnd(ArtMethod* method) {
-  if (UNLIKELY(method->is_trace_enabled)) {
+  if (method->is_trace_enabled) {
     if (LIKELY(tlsPtr_.trace_data_ptr != nullptr)) {
       *tlsPtr_.trace_data_ptr++ = 0;
       *tlsPtr_.trace_data_ptr++ = generic_timer_count();


### PR DESCRIPTION
**Background**
A branch misprediction is quite expensive. A mispredicted branch can easily be 10x more expensive than a correctly predicted branch.

So this compiler hint is likely doubling the cost of this method. Until we use blacklisting it doesn't make sense to include this. Unless we make big bets on blacklisting it might even be cheaper to remove support for blacklisting altoghether.