### PR TITLE
Ensure that tbclk is read every time we call `generic_time_count()`

### DIFF
--- a/runtime/thread.cc
+++ b/runtime/thread.cc
@@ -109,7 +109,7 @@ uint64_t ALWAYS_INLINE generic_timer_count() {
   uint64_t t = 0;
 #if defined(__arm__)
   uint32_t t1, t2;
-  asm("mrrc p15, 1, %0, %1, c14" : "=r"(t1), "=r"(t2));
+  asm volatile("mrrc p15, 1, %0, %1, c14" : "=r"(t1), "=r"(t2));
   t = t2;
   t = t << 32 | t1;
 #elif defined(__aarch64__)


### PR DESCRIPTION
I noticed that there are circumstances where calling `generic_timer_count()` will result in the `tbclk` register not being reread. This is because of compiler optimizations. Using the volatile asm statement prevents this.