### PR TITLE
Include class name in more ClassLinker spans. Fix bug.

### DIFF
--- a/runtime/mirror/class.cc
+++ b/runtime/mirror/class.cc
@@ -824,6 +824,21 @@ const char* Class::GetDescriptor(std::string* storage) {
   }
 }
 
+const char* Class::GetDescriptorAssumingDex(std::string* storage) {
+  if (UNLIKELY(IsPrimitive())) {
+    return Primitive::Descriptor(GetPrimitiveType());
+  } else if (UNLIKELY(IsArrayClass())) {
+    return GetArrayDescriptor(storage);
+  } else if (UNLIKELY(IsProxyClass())) {
+    *storage = Runtime::Current()->GetClassLinker()->GetDescriptorForProxy(this);
+    return storage->c_str();
+  } else {
+    const DexFile& dex_file = GetDexFile();
+    const DexFile::TypeId& type_id = dex_file.GetTypeId(GetClassDef()->class_idx_);
+    return dex_file.GetTypeDescriptor(type_id);
+  }
+}
+
 const char* Class::GetArrayDescriptor(std::string* storage) {
   std::string temp;
   const char* elem_desc = GetComponentType()->GetDescriptor(&temp);

--- a/runtime/mirror/class.h
+++ b/runtime/mirror/class.h
@@ -1163,6 +1163,7 @@ class MANAGED Class FINAL : public Object {
   // always create one the storage argument is populated and its internal c_str() returned. We do
   // this to avoid memory allocation in the common case.
   const char* GetDescriptor(std::string* storage) SHARED_REQUIRES(Locks::mutator_lock_);
+  const char* GetDescriptorAssumingDex(std::string* storage) SHARED_REQUIRES(Locks::mutator_lock_);
 
   const char* GetArrayDescriptor(std::string* storage) SHARED_REQUIRES(Locks::mutator_lock_);
 

--- a/runtime/nanoscope.h
+++ b/runtime/nanoscope.h
@@ -20,7 +20,7 @@
 #include "thread.h"
 
 #define NANO_TRACE_SCOPE_FROM_STRING(thread_self, name_string) FromStringScopedArtTrace ___nano_tracer(thread_self, reinterpret_cast<const char *>(name_string))
-#define NANO_TRACE_SCOPE_FROM_STRING_AND_META(thread_self, name_string, meta) FromStringAndMetaScopedArtTrace ___nano_tracer(thread_self, reinterpret_cast<const char *>(name_string), reinterpret_cast<const char *>(meta))
+#define NANO_TRACE_SCOPE_FROM_STRING_AND_META(thread_self, name_string, meta) FromStringAndMetaScopedArtTrace ___nano_tracer_with_meta(thread_self, reinterpret_cast<const char *>(name_string), reinterpret_cast<const char *>(meta))
 
 class FromStringScopedArtTrace {
  private:


### PR DESCRIPTION
1) Include the class name in more spans. There isn't a one to one mapping between Initialize() calls DefineClase() calls. So I wanted to include names in both Initialize() and DefineClass() calls. However, instead of directly including the name inside DefineClass() calls I profile LoadClass() and LinkClass() calls (since the name isn't reliably setup at the beginning of DefineClass())
2) No longer rely on the descriptor passed around. In some rare circumstances (mostly proxy classes) this descriptor doesn't exist inside a global scope. This fixes https://github.com/uber/nanotracer-art/issues/8.

Some background on how often these class linker methods get called on the main thread:

RIDER APP STARTUP:
LinkClass: 21354
DefineClass: 21354
LoadClass: 20806
InitializeClass: 10320

RIDER APP CONFIRMATION TRANSITION:
LinkClass: 357
DefineClass: 356
LoadClass: 356
InitializeClass: 1,240
Methods In Span: 400,000