### PR TITLE
Add target to run Nanoscope integration tests.

### DIFF
--- a/test/run-test
+++ b/test/run-test
@@ -904,4 +904,4 @@ fi
 
 ) 2>&${real_stderr} 1>&2
 
-exit 1
+exit 0


### PR DESCRIPTION
To run Nanoscope integration tests, execute the following command:

```
mma run-nanoscope-tests
```

If you've run the command previously, `mm` should be sufficient.