### PR TITLE
Fix OOMs by adding back original system properties

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -613,7 +613,7 @@ ROM_FILENAMES := \
 
 ROM_FILE_DEPENDENCIES := $(foreach file, $(ROM_FILENAMES), $(PRODUCT_OUT)/$(file))
 
-export ADDITIONAL_BUILD_PROPERTIES="ro.build.nanoscope=$(ROM_VERSION)"
+ADDITIONAL_BUILD_PROPERTIES += "ro.build.nanoscope=$(ROM_VERSION)"
 
 $(ROM_INSTALL_FILE):
 	cp $(art_path)/__install.sh $(ROM_INSTALL_FILE)


### PR DESCRIPTION
The original change incorrectly overwrote the existing `ADDITIONAL_BUILD_PROPERTIES` variable with our new property.  This wiped out ~70 system properties. This fix correctly appends our new property to the list.

**How did we find this bug?**
The symptom was a consistent OOM thrown by `WallpaperManager` when loading the device wallpaper. A manual git bisect revealed 2633b73f to be the first bad commit. It was unclear from the commit what was causing the bug, but the diff of `$ANDROID_PRODUCT_OUT/installed-files.txt` between versions identified `system/build.props` to be the only changed file:

```diff
diff --git a/installed-files.txt b/installed-files.txt
index 11f6f2e..11afb2f 100644
--- a/installed-files.txt
+++ b/installed-files.txt
@@ -1367,7 +1367,6 @@
         4355  /system/etc/security/cacerts/b7db1890.0
         4333  /system/etc/security/cacerts/ab5346f4.0
         4332  /system/etc/security/cacerts/1e8e7201.0
-        4317  /system/build.prop
         4312  /system/etc/security/cacerts/7999be0d.0
         4300  /system/etc/security/cacerts/12d55845.0
         4296  /system/etc/init/atrace.rc
@@ -1431,6 +1430,7 @@
         2188  /system/etc/init/dumpstate.rc
         2105  /system/etc/r_submix_audio_policy_configuration.xml
         2022  /system/usr/hyphen-data/hyph-hu.lic.txt
+        2004  /system/build.prop
         1994  /system/usr/keylayout/Vendor_22b8_Product_093d.kl
         1936  /system/etc/usb_audio_policy_configuration.xml
         1919  /system/etc/bluetooth/bt_stack.conf
```

It was clear from the two `build.prop` versions that we were throwing away all of the properties in the `ADDITIONAL_PROPERTIES` section:

```diff
diff --git a/system/build.prop b/system/build.prop
index 2662588..6bf5a33 100644
--- a/system/build.prop
+++ b/system/build.prop
@@ -12,8 +12,8 @@ import /oem/oem.prop oem.*
 # begin build properties
 # autogenerated by buildinfo.sh
 ro.build.id=N2G48C
-ro.build.display.id=aosp_angler-userdebug 7.1.2 N2G48C eng.leland.20180322.22
3029 test-keys
-ro.build.version.incremental=eng.leland.20180322.223029
+ro.build.display.id=aosp_angler-userdebug 7.1.2 N2G48C eng.leland.20180322.22
3448 test-keys
+ro.build.version.incremental=eng.leland.20180322.223448
 ro.build.version.sdk=25
 ro.build.version.preview_sdk=0
 ro.build.version.codename=REL
@@ -21,8 +21,8 @@ ro.build.version.all_codenames=REL
 ro.build.version.release=7.1.2
 ro.build.version.security_patch=2017-08-05
 ro.build.version.base_os=
-ro.build.date=Thu Mar 22 22:30:29 PDT 2018
-ro.build.date.utc=1521783029
+ro.build.date=Thu Mar 22 22:34:48 PDT 2018
+ro.build.date.utc=1521783288
 ro.build.type=userdebug
 ro.build.user=lelandtakamine
 ro.build.host=leland-C02VL0FPHTDG
@@ -46,83 +46,13 @@ ro.board.platform=msm8994
 # ro.build.product is obsolete; use ro.product.device
 ro.build.product=angler
 # Do not try to parse description, fingerprint, or thumbprint
-ro.build.description=aosp_angler-userdebug 7.1.2 N2G48C eng.leland.20180322.2
23029 test-keys
-ro.build.fingerprint=Android/aosp_angler/angler:7.1.2/N2G48C/leland03222230:u
serdebug/test-keys
+ro.build.description=aosp_angler-userdebug 7.1.2 N2G48C eng.leland.20180322.2
23448 test-keys
+ro.build.fingerprint=Android/aosp_angler/angler:7.1.2/N2G48C/leland03222234:u
serdebug/test-keys
 ro.build.characteristics=nosdcard
 # end build properties

 #
 # ADDITIONAL_BUILD_PROPERTIES
 #
-keyguard.no_require_sim=true
-ro.com.android.dataroaming=true
-ro.config.ringtone=Ring_Synth_04.ogg
-ro.config.notification_sound=pixiedust.ogg
-ro.carrier=unknown
-ro.config.alarm_alert=Alarm_Classic.ogg
-ro.opengles.version=196610
-ro.sf.lcd_density=560
-persist.hwc.mdpcomp.enable=true
-persist.data.mode=concurrent
-persist.radio.data_no_toggle=1
-persist.radio.data_con_rprt=true
-ro.hwui.texture_cache_size=72
-ro.hwui.layer_cache_size=48
-ro.hwui.r_buffer_cache_size=8
-ro.hwui.path_cache_size=32
-ro.hwui.gradient_cache_size=1
-ro.hwui.drop_shadow_cache_size=6
-ro.hwui.texture_cache_flushrate=0.4
-ro.hwui.text_small_cache_width=1024
-ro.hwui.text_small_cache_height=1024
-ro.hwui.text_large_cache_width=2048
-ro.hwui.text_large_cache_height=1024
-vidc.debug.perf.mode=2
-vidc.enc.dcvs.extra-buff-count=2
-ro.min_freq_0=384000
-ro.vendor.extension_library=libqti-perfd-client.so
-rild.libpath=/vendor/lib64/libril-qc-qmi-1.so
-ro.telephony.default_cdma_sub=0
-ro.telephony.default_network=10
-telephony.lteOnCdmaDevice=1
-persist.radio.mode_pref_nv10=1
-persist.radio.apm_sim_not_pwdn=1
-persist.radio.custom_ecc=1
-persist.data.iwlan.enable=true
-ro.frp.pst=/dev/block/platform/soc.0/f9824900.sdhci/by-name/frp
-persist.radio.always_send_plmn=true
-ro.telephony.call_ring.multiple=0
-af.fast_track_multiplier=1
-audio_hal.period_size=192
-ro.qc.sdk.audio.fluencetype=fluence
-persist.audio.fluence.voicecall=true
-persist.audio.fluence.voicecomm=true
-persist.audio.product.identify=angler
-persist.audio.fluence.speaker=true
-media.aac_51_output_enabled=true
-ro.audio.monitorRotation=true
-ro.audio.flinger_standbytime_ms=300
-persist.sys.ssr.restart_level=ALL_ENABLE
-persist.camera.eis.enable=1
-persist.camera.is_type=4
-dalvik.vm.boot-dex2oat-threads=4
-dalvik.vm.dex2oat-threads=4
-dalvik.vm.image-dex2oat-threads=4
-persist.sys.ssr.enable_ramdumps=1
-persist.radio.redir_party_num=0
-ro.product.first_api_level=23
-dalvik.vm.heapstartsize=8m
-dalvik.vm.heapgrowthlimit=192m
-dalvik.vm.heapsize=512m
-dalvik.vm.heaptargetutilization=0.75
-dalvik.vm.heapminfree=512k
-dalvik.vm.heapmaxfree=8m
-persist.sys.dalvik.vm.lib.2=libart.so
-dalvik.vm.isa.arm64.variant=cortex-a53
-dalvik.vm.isa.arm64.features=default
-dalvik.vm.isa.arm.variant=cortex-a53.a57
-dalvik.vm.isa.arm.features=default
-dalvik.vm.lockprof.threshold=500
-net.bt.name=Android
-dalvik.vm.stack-trace-file=/data/anr/traces.txt
-ro.expect.recovery_id=0xd3a9458daf2cf9209e8977925e5599848aa3173b000000000000000000000000
+ro.build.nanoscope=0.1.0
+ro.expect.recovery_id=0x8f7ff1f8e14cb8e9689b6317a69ee080c04f15fc000000000000000000000000
```

In particular, the absence of `dalvik.vm.heapsize=512m` forced a heap size fallback of just [16MB](https://android.googlesource.com/platform/frameworks/base.git/+/android-4.2.2_r1/core/jni/AndroidRuntime.cpp#546).

