### PR TITLE
Wipe device when flashing

### DIFF
--- a/__install.sh
+++ b/__install.sh
@@ -64,7 +64,7 @@ function flash() {
 	set -e
 	ensure_bootloader_unlocked
 	ensure_on_bootloader
-	ANDROID_PRODUCT_OUT=$WORK_DIR fastboot flashall
+	ANDROID_PRODUCT_OUT=$WORK_DIR fastboot flashall -w
 }
 
 function ensure_overlay_downloaded() {


### PR DESCRIPTION
We're more likely run into issues with a "dirty" flash. For now, just wipe the device so we have a better flash success rate.