### PR TITLE
Prevent double start for startup tracing

### DIFF
--- a/runtime/nanoscope_propertywatcher.h
+++ b/runtime/nanoscope_propertywatcher.h
@@ -91,6 +91,8 @@ class NanoscopePropertyWatcher {
 
       stop_tracing(self);
     } else {
+      if (!output_path.empty()) return;
+
       std::stringstream ss(value);
 
       std::string _package_name;


### PR DESCRIPTION
`NanoscopePropertyWatcher::watch` logic assumes that `refresh_state` is idempotent with respect to the system property value. This change fixes a bug where this was not the case. We now make sure `start_tracing` is only called once for multiple `refresh_state` calls.