### PR TITLE
Add Sampling to Nanoscope-art. 

### DIFF
--- a/runtime/Android.mk
+++ b/runtime/Android.mk
@@ -131,6 +131,7 @@ LIBART_COMMON_SRC_FILES := \
   mirror/string.cc \
   mirror/throwable.cc \
   monitor.cc \
+  nanoscope_sampler.cc \
   native_bridge_art_interface.cc \
   native/dalvik_system_DexFile.cc \
   native/dalvik_system_VMDebug.cc \

--- a/runtime/asm_support.h
+++ b/runtime/asm_support.h
@@ -113,7 +113,7 @@ ADD_TEST_EQ(THREAD_TRACE_DATA_OFFSET,
             art::Thread::TraceDataPtrOffset<__SIZEOF_POINTER__>().Int32Value())
 
 // Offset of field Thread::tlsPtr_.card_table.
-#define THREAD_CARD_TABLE_OFFSET (THREAD_TRACE_DATA_OFFSET + (2 * __SIZEOF_POINTER__))
+#define THREAD_CARD_TABLE_OFFSET (THREAD_TRACE_DATA_OFFSET + (6 * __SIZEOF_POINTER__))
 ADD_TEST_EQ(THREAD_CARD_TABLE_OFFSET,
             art::Thread::CardTableOffset<__SIZEOF_POINTER__>().Int32Value())
 

--- a/runtime/entrypoints/quick/quick_jni_entrypoints.cc
+++ b/runtime/entrypoints/quick/quick_jni_entrypoints.cc
@@ -36,6 +36,7 @@ extern uint32_t JniMethodStart(Thread* self) {
   uint32_t saved_local_ref_cookie = env->local_ref_cookie;
   env->local_ref_cookie = env->locals.GetSegmentState();
   ArtMethod* native_method = *self->GetManagedStack()->GetTopQuickFrame();
+  self->TraceStart(native_method);
   if (!native_method->IsFastNative()) {
     // When not fast JNI we transition out of runnable.
     self->TransitionFromRunnableToSuspended(kNative);
@@ -76,6 +77,7 @@ static void PopLocalReferences(uint32_t saved_local_ref_cookie, Thread* self)
 extern void JniMethodEnd(uint32_t saved_local_ref_cookie, Thread* self) {
   GoToRunnable(self);
   PopLocalReferences(saved_local_ref_cookie, self);
+  self->TraceEnd();
 }
 
 extern void JniMethodEndSynchronized(uint32_t saved_local_ref_cookie, jobject locked,
@@ -83,6 +85,7 @@ extern void JniMethodEndSynchronized(uint32_t saved_local_ref_cookie, jobject lo
   GoToRunnable(self);
   UnlockJniSynchronizedMethod(locked, self);  // Must decode before pop.
   PopLocalReferences(saved_local_ref_cookie, self);
+  self->TraceEnd();
 }
 
 // Common result handling for EndWithReference.
@@ -98,6 +101,7 @@ static mirror::Object* JniMethodEndWithReferenceHandleResult(jobject result,
     CheckReferenceResult(o, self);
   }
   VerifyObject(o);
+  self->TraceEnd();
   return o;
 }
 
@@ -139,6 +143,7 @@ extern uint64_t GenericJniMethodEnd(Thread* self,
       UnlockJniSynchronizedMethod(locked, self);  // Must decode before pop.
     }
     PopLocalReferences(saved_local_ref_cookie, self);
+    self->TraceEnd();
     switch (return_shorty_char) {
       case 'F': {
         if (kRuntimeISA == kX86) {

--- a/runtime/interpreter/interpreter.cc
+++ b/runtime/interpreter/interpreter.cc
@@ -319,12 +319,12 @@ static inline JValue Execute(
         // No Mterp variant - just use the switch interpreter.
         result_register = ExecuteSwitchImpl<false, true>(self, code_item, shadow_frame, result_register,
                                               false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       } else if (UNLIKELY(!Runtime::Current()->IsStarted())) {
         result_register = ExecuteSwitchImpl<false, false>(self, code_item, shadow_frame, result_register,
                                                false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       } else {
         while (true) {
@@ -332,19 +332,19 @@ static inline JValue Execute(
           if (MterpShouldSwitchInterpreters()) {
             result_register = ExecuteSwitchImpl<false, false>(self, code_item, shadow_frame, result_register,
                                                    false);
-            self->TraceEnd(method);
+            self->TraceEnd();
             return result_register;
           }
           bool returned = ExecuteMterpImpl(self, code_item, &shadow_frame, &result_register);
           if (returned) {
-            self->TraceEnd(method);
+            self->TraceEnd();
             return result_register;
           } else {
             // Mterp didn't like that instruction.  Single-step it with the reference interpreter.
             result_register = ExecuteSwitchImpl<false, false>(self, code_item, shadow_frame,
                                                                result_register, true);
             if (shadow_frame.GetDexPC() == DexFile::kDexNoIndex) {
-              self->TraceEnd(method);
+              self->TraceEnd();
               // Single-stepped a return or an exception not handled locally.  Return to caller.
               return result_register;
             }
@@ -355,23 +355,23 @@ static inline JValue Execute(
       if (transaction_active) {
         result_register = ExecuteSwitchImpl<false, true>(self, code_item, shadow_frame, result_register,
                                               false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       } else {
         result_register = ExecuteSwitchImpl<false, false>(self, code_item, shadow_frame, result_register,
                                                false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       }
     } else {
       DCHECK_EQ(kInterpreterImplKind, kComputedGotoImplKind);
       if (transaction_active) {
         result_register = ExecuteGotoImpl<false, true>(self, code_item, shadow_frame, result_register);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       } else {
         result_register = ExecuteGotoImpl<false, false>(self, code_item, shadow_frame, result_register);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       }
     }
@@ -382,35 +382,35 @@ static inline JValue Execute(
       if (transaction_active) {
         result_register = ExecuteSwitchImpl<true, true>(self, code_item, shadow_frame, result_register,
                                              false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       } else {
         result_register = ExecuteSwitchImpl<true, false>(self, code_item, shadow_frame, result_register,
                                               false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       }
     } else if (kInterpreterImplKind == kSwitchImplKind) {
       if (transaction_active) {
         result_register = ExecuteSwitchImpl<true, true>(self, code_item, shadow_frame, result_register,
                                              false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       } else {
         result_register = ExecuteSwitchImpl<true, false>(self, code_item, shadow_frame, result_register,
                                               false);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       }
     } else {
       DCHECK_EQ(kInterpreterImplKind, kComputedGotoImplKind);
       if (transaction_active) {
         result_register = ExecuteGotoImpl<true, true>(self, code_item, shadow_frame, result_register);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       } else {
         result_register = ExecuteGotoImpl<true, false>(self, code_item, shadow_frame, result_register);
-        self->TraceEnd(method);
+        self->TraceEnd();
         return result_register;
       }
     }

--- a/runtime/nanoscope_propertywatcher.h
+++ b/runtime/nanoscope_propertywatcher.h
@@ -25,8 +25,9 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <cutils/process_name.h>
+#include "nanoscope_sampler.h"
 
-#if defined(__linux__)
+#if defined(__ANDROID__)
 // Need this next line to get around a check in "sys/_system_properties.h". These APIs are definitely not meant for
 // external use, but it's the only way to observe system property changes.
 #define _REALLY_INCLUDE_SYS__SYSTEM_PROPERTIES_H_
@@ -35,6 +36,7 @@
 #endif
 
 namespace art {
+
 
 // This class enables starting and stopping tracing by setting the "dev.nanoscope" system property. For example, the
 // command below starts tracing the com.example process on the thread passed to NanoScopePropertyWatcher::attach_to:
@@ -46,32 +48,45 @@ namespace art {
 //     $ adb shell setprop dev.nanoscope \'\'
 //
 // It's valid to set this property before the process is started. In this case, the tracing will be triggered on app start.
+
+// Currently provides two ways of generating sampling signals:
+// perf_timer mode: uses perf_event_open to set up counter that sends overflow signals, sampling interval is based on wall clock time
+// cpu_timer mode: uses timer_settime to wake up and send signals periodically, samping interval is based on cpu time
+// Enabling sampling by selecting one of the sampling mode, for example, the commands below enables sampling in perf_timer mode
+//
+//     $ adb shell setprop dev.nanoscope com.example:data.txt:perf_timer
+//
+// The commands below enables sampling in cpu_timer mode:
+//
+//     $ adb shell setprop dev.nanoscope com.example:data.txt:cpu_timer
+//
 class NanoscopePropertyWatcher {
  public:
   static void attach(std::string package_name) {
-    Thread* traced = Thread::Current();
-    NanoscopePropertyWatcher* watcher = new NanoscopePropertyWatcher(traced, package_name);
+    Thread* monitored_thread_ = Thread::Current();
+    NanoscopePropertyWatcher* watcher = new NanoscopePropertyWatcher(monitored_thread_, package_name);
     watcher->watch();
   }
 
  private:
-  Thread* const traced;
-  const std::string package_name;
-  const std::string watched_properties[3] = {"dev.nanoscope", "dev.arttracing", "arttracing"};
-  const std::string output_dir = "/data/data/" + package_name + "/files";
+  const std::string package_name_;
+  const std::string watched_properties_[3] = {"dev.nanoscope", "dev.arttracing", "arttracing"};
+  const std::string output_dir_ = "/data/data/" + package_name_ + "/files";
+  std::string output_path_;
 
-  std::string output_path;
+  // Thread current nanoscope watcher thread is monitoring
+  Thread* monitored_thread_;
 
-  explicit NanoscopePropertyWatcher(Thread* _traced, std::string _package_name) : traced(_traced), package_name(_package_name) {}
+  explicit NanoscopePropertyWatcher(Thread* t, std::string _package_name) : package_name_(_package_name), monitored_thread_(t) {}
 
   void watch() {
     refresh_state(Thread::Current());
-    std::string thread_name = "nanoscope-propertywatcher:" + package_name;
+    std::string thread_name = "nanoscope-propertywatcher:" + package_name_;
 
     NanoscopePropertyWatcher* watcher = this;
     new std::thread([watcher, thread_name]() {
       Thread* self = Thread::Attach(thread_name.c_str(), false, nullptr, false);
-#if defined(__linux__)
+#if defined(__ANDROID__)
       unsigned int serial = 0;
       while (1) {
         serial = __system_property_wait_any(serial);
@@ -87,33 +102,54 @@ class NanoscopePropertyWatcher {
     std::string value = get_system_property_value();
 
     if (value.empty()) {
-      if (output_path.empty()) return;
+      if (output_path_.empty()) return;
 
+      NanoscopeSampler::StopSampling();
       stop_tracing(self);
     } else {
+      if (!output_path_.empty()) return;
+
       std::stringstream ss(value);
 
       std::string _package_name;
       std::getline(ss, _package_name, ':');
-      if (_package_name.compare(package_name) != 0) {
+      if (_package_name.compare(package_name_) != 0) {
         return;
       }
 
       std::string output_filename;
-      std::getline(ss, output_filename);
+      std::getline(ss, output_filename, ':');
       if (output_filename.empty()) {
         LOG(INFO) << "nanoscope: Failed to parse output filename: " << value;
         return;
       }
 
-      start_tracing(self, output_dir + "/" + output_filename);
+      std::string timer_mode;
+      std::getline(ss, timer_mode);
+
+      SampleMode sample_mode;
+      if(timer_mode == "perf_timer"){
+        LOG(INFO) << "nanoscope: sampling enabled, timer mode: " << timer_mode;
+        sample_mode = kSamplePerf;
+      } else if (timer_mode == "cpu_timer"){
+        LOG(INFO) << "nanoscope: sampling enabled, timer mode: " << timer_mode;
+        sample_mode = kSampleCpu;
+      } else {
+        LOG(INFO) << "nanoscope: sampling disabled";
+        sample_mode = kSampleDisabled;
+      }
+
+      start_tracing(self, output_dir_ + "/" + output_filename);
+      if(sample_mode != kSampleDisabled){
+        NanoscopeSampler::StartSampling(monitored_thread_, sample_mode);
+      }
     }
   }
 
   std::string get_system_property_value() {
     char* buffer = new char[1028];
-#if defined(__linux__)
-    for (std::string watched_property : watched_properties) {
+#if defined(__ANDROID__)
+    for (std::string watched_property : watched_properties_) {
       int length = __system_property_get(watched_property.c_str(), buffer);
       if (length > 0) break;
     }
@@ -121,26 +157,27 @@ class NanoscopePropertyWatcher {
     return std::string(buffer);
   }
 
-  void start_tracing(Thread* self, std::string _output_path) {
-    output_path = _output_path;
-    remove(output_path.c_str());
+  void start_tracing(Thread* self, std::string output_path) {
+    output_path_ = output_path;
+    remove(output_path_.c_str());
 
+    // Start Nanoscope tracing
     Locks::mutator_lock_->SharedLock(self);
-    traced->StartTracing();
+    monitored_thread_->StartTracing();
     Locks::mutator_lock_->SharedUnlock(self);
   }
 
   void stop_tracing(Thread* self) {
-    if (output_path.empty()) {
+    if (output_path_.empty()) {
       LOG(ERROR) << "nanoscope: No output path found.";
       return;
     }
 
+    // Stop tracing
     Locks::mutator_lock_->SharedLock(self);
-    traced->StopTracing(output_path);
+    monitored_thread_->StopTracing(output_path_);
     Locks::mutator_lock_->SharedUnlock(self);
-
-    output_path = "";
+    output_path_ = "";
   }
 };
 

--- a/runtime/nanoscope_sampler.cc
+++ b/runtime/nanoscope_sampler.cc
@@ -1,0 +1,235 @@
+#include "nanoscope_sampler.h"
+#if defined(__ANDROID__)
+#include <linux/perf_event.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <asm/unistd.h>
+#include <time.h>
+#include "thread.h"
+
+// perf_event_open API
+static int perf_event_open(const perf_event_attr& attr, pid_t pid, int cpu,
+                           int group_fd, unsigned long flags) {  // NOLINT
+  return syscall(__NR_perf_event_open, &attr, pid, cpu, group_fd, flags);
+}
+#include <linux/unistd.h>
+#include <signal.h>
+#include <time.h>
+#endif
+
+namespace art{
+Thread* NanoscopeSampler::sampling_thread_ = NULL;
+SampleMode NanoscopeSampler::sample_mode_ = kSampleDisabled;
+#if defined(__ANDROID__)
+int64_t NanoscopeSampler::sample_interval_ = 1000000;         // 1000000ns
+int NanoscopeSampler::perf_timer_fd_ = -1;
+int NanoscopeSampler::sample_fd_ [] = { [0 ... (COUNTER_TYPE_LIMIT - 1)] = -1 };
+struct perf_event_mmap_page* NanoscopeSampler::perf_timer_page_ = NULL;
+timer_t NanoscopeSampler::timer_id_ = 0;
+#endif
+
+void NanoscopeSampler::set_up_timer(){
+#if defined(__ANDROID__)
+if(sample_mode_ == kSamplePerf){
+  // Set up perf_event counter that acts as a timer
+  struct perf_event_attr pe;
+  memset(&pe, 0, sizeof(struct perf_event_attr));
+  pe.type = PERF_TYPE_SOFTWARE;
+  pe.size = sizeof(struct perf_event_attr);
+  pe.config = PERF_COUNT_SW_CPU_CLOCK;
+  pe.sample_period = sample_interval_;
+  pe.sample_type = PERF_SAMPLE_TIME;
+  pe.read_format = PERF_FORMAT_GROUP|PERF_FORMAT_ID;
+  pe.disabled = 1;
+  pe.pinned = 1;
+  pe.wakeup_events = 1;
+
+  // perf_event_open pid = -1, cpuid = 0, counts cpu time of all threads on cpu0
+  // which essentially gives us wall clock time
+  perf_timer_fd_ = perf_event_open(pe, -1, 0, -1, 0);
+  if (perf_timer_fd_ < 0) {
+    LOG(ERROR) << "nanoscope: Fail to open perf event file: master ";
+    LOG(ERROR) << "nanoscope: " << strerror(errno);
+    return;
+  }
+
+  void* p = mmap(NULL, (1+1)*PERF_PAGE_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, perf_timer_fd_, 0);
+  perf_timer_page_ = (struct perf_event_mmap_page*)p;
+  fcntl(perf_timer_fd_, F_SETFL, O_ASYNC);
+  fcntl(perf_timer_fd_, F_SETSIG, SIGTIMER);
+
+  // Deliver the signal to the tracing thread when counter overflows
+  struct f_owner_ex fown_ex;
+  fown_ex.type = F_OWNER_TID;
+  fown_ex.pid  = sampling_thread_->GetTid();
+  int ret = fcntl(perf_timer_fd_, F_SETOWN_EX, &fown_ex);
+  if (ret == -1) {
+    LOG(ERROR) << "nanoscope: Failed to set the owner of the perf event file";
+    return;
+  }
+} else if (sample_mode_ == kSampleCpu){
+  struct sigevent sev;
+  struct itimerspec its;
+  long long freq_nanosecs;
+  sev.sigev_notify = SIGEV_THREAD_ID;
+  sev.sigev_signo = SIGTIMER;
+  sev.sigev_notify_thread_id = sampling_thread_ -> GetTid();
+  sev.sigev_value.sival_ptr = &timer_id_;
+  if (timer_create(CLOCK_THREAD_CPUTIME_ID, &sev, &timer_id_) == -1)
+    LOG(ERROR) << "nanoscope: Failed to create timer";;
+    freq_nanosecs = sample_interval_;   // 1ms
+    its.it_value.tv_sec = freq_nanosecs / 1000000000;
+    its.it_value.tv_nsec = freq_nanosecs % 1000000000;
+    its.it_interval.tv_sec = its.it_value.tv_sec;
+    its.it_interval.tv_nsec = its.it_value.tv_nsec;
+
+    if (timer_settime(timer_id_, 0, &its, NULL) == -1)
+      LOG(ERROR) << "nanoscope: Failed to set timer";;
+  } else {
+    UNREACHABLE();
+  }
+#endif
+}
+
+#if defined(__ANDROID__)
+void NanoscopeSampler::set_up_sample_counter(CounterType counter_type, int groupfd){
+  uint64_t type, config;
+  switch(counter_type){
+    case COUNTER_TYPE_MAJOR_PAGE_FAULTS:
+      type = PERF_TYPE_SOFTWARE;
+      config = PERF_COUNT_SW_PAGE_FAULTS_MAJ;
+      break;
+    case COUNTER_TYPE_MINOR_PAGE_FAULTS:
+      type = PERF_TYPE_SOFTWARE;
+      config = PERF_COUNT_SW_PAGE_FAULTS_MIN;
+      break;
+    case COUNTER_TYPE_CONTEXT_SWITCHES:
+      type = PERF_TYPE_SOFTWARE;
+      config = PERF_COUNT_SW_CONTEXT_SWITCHES;
+      break;
+    default:
+      LOG(ERROR) << "nanoscope: wrong counter type";
+      return;
+  }
+
+  // Set up counter
+  struct perf_event_attr pe;
+  memset(&pe, 0, sizeof(struct perf_event_attr));
+  pe.type = type;
+  pe.size = sizeof(struct perf_event_attr);
+  pe.config = config;
+  pe.read_format = PERF_FORMAT_GROUP|PERF_FORMAT_ID;
+  pe.disabled = 1;
+
+  // Pid = tracing thread's tid, cpuid = -1. Counts tracing thread on any cpu.
+  sample_fd_[counter_type] = perf_event_open(pe, sampling_thread_->GetTid(), -1, groupfd, 0);
+  if (sample_fd_[counter_type] < 0) {
+    LOG(ERROR) << "nanoscope: Fail to open perf event file: slave ";
+    LOG(ERROR) << "nanoscope: " << strerror(errno);
+    return;
+  }
+  fcntl(sample_fd_[counter_type], F_SETFL, O_ASYNC);
+}
+
+void NanoscopeSampler::signal_handler(int sigo ATTRIBUTE_UNUSED, siginfo_t *siginfo ATTRIBUTE_UNUSED, void *ucontext ATTRIBUTE_UNUSED) {
+  // Read perf_event sample values
+  char buf[4096];
+  struct read_format* rf = (struct read_format*) buf;
+  read(sample_fd_[0], buf, sizeof(buf));
+  uint64_t vals[COUNTER_TYPE_LIMIT] = {0};
+  for(int i = 0; i < COUNTER_TYPE_LIMIT; i++){
+    vals[i] = rf->values[i].value;
+  }
+
+  // Read thread CPU time
+  struct timespec thread_cpu_time;
+  if(clock_gettime(CLOCK_THREAD_CPUTIME_ID, &thread_cpu_time) < 0){
+    LOG(ERROR) << "nanoscope: error get clock time";
+  }
+
+  sampling_thread_ -> TimerHandler(thread_cpu_time.tv_sec * 1e+9 + thread_cpu_time.tv_nsec, vals[0], vals[1], vals[2]);
+
+  // Restart timer
+  if(sample_mode_ == kSamplePerf){
+    ioctl(perf_timer_fd_, PERF_EVENT_IOC_RESET, 0);
+    ioctl(perf_timer_fd_, PERF_EVENT_IOC_REFRESH, 1);
+  }
+}
+
+void NanoscopeSampler::install_sig_handler() {
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(struct sigaction));
+  sa.sa_sigaction = signal_handler;
+  sa.sa_flags = SA_RESTART | SA_SIGINFO;
+  if (sigaction(SIGTIMER, &sa, NULL) < 0) {
+    LOG(ERROR) << "nanoscope: Error setting up signal handler.";
+    return;
+  }
+  LOG(INFO) << "nanoscope: set up sig handler for SIGTIMER";
+}
+#endif
+
+void NanoscopeSampler::StartSampling(Thread* t, SampleMode sample_mode){
+  sampling_thread_ = t;
+  sample_mode_ = sample_mode;
+
+#if defined(__ANDROID__)
+  // Set up sampling
+  install_sig_handler();
+  set_up_timer();
+
+  // Set up perf_event counters used to gather sampling data
+  // All counters are in the same perf_event group, with the leader being the first counter
+  // so that we can read all of them at the same time
+  set_up_sample_counter(COUNTER_TYPE_MAJOR_PAGE_FAULTS, -1);
+  set_up_sample_counter(COUNTER_TYPE_MINOR_PAGE_FAULTS, sample_fd_[0]);
+  set_up_sample_counter(COUNTER_TYPE_CONTEXT_SWITCHES, sample_fd_[0]);
+
+  // Enable allocation stats counter
+  Runtime::Current()->SetStatsEnabled(true);
+
+  // Starts all counters
+  ioctl(perf_timer_fd_, PERF_EVENT_IOC_RESET, 0);
+  ioctl(perf_timer_fd_, PERF_EVENT_IOC_REFRESH, 1);
+  ioctl(sample_fd_[0], PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
+  ioctl(sample_fd_[0], PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
+#endif
+}
+
+void NanoscopeSampler::StopSampling(){
+#if defined(__ANDROID__)
+  if(sample_mode_ == kSamplePerf){
+    // Disable allocation stats counter
+    Runtime::Current()->SetStatsEnabled(false);
+
+    // Delete perf_event counter that acts as a timer
+    ioctl(perf_timer_fd_, PERF_EVENT_IOC_DISABLE, 0);
+    close(perf_timer_fd_);
+    perf_timer_fd_ = 0;
+    munmap(perf_timer_page_, 2 * PERF_PAGE_SIZE);
+    perf_timer_page_ = NULL;
+
+    // Delete perf_event counters used to gather sampling data
+    ioctl(sample_fd_[0], PERF_EVENT_IOC_DISABLE, 0);
+    for(int i = 0; i < COUNTER_TYPE_LIMIT; i++){
+      close(sample_fd_[i]);
+      sample_fd_[i] = 0;
+    }
+  } else if(sample_mode_ == kSampleCpu) {
+    // Disable allocation stats counter
+    Runtime::Current()->SetStatsEnabled(false);
+
+    // Delete timer_settime timer
+    timer_delete(timer_id_);
+
+    // Delete perf_event counters used to gather sampling data
+    ioctl(sample_fd_[0], PERF_EVENT_IOC_DISABLE, 0);
+    for(int i = 0; i < COUNTER_TYPE_LIMIT; i++){
+      close(sample_fd_[i]);
+      sample_fd_[i] = 0;
+    }
+  }
+#endif
+}
+
+}

--- a/runtime/nanoscope_sampler.h
+++ b/runtime/nanoscope_sampler.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ART_RUNTIME_NANOSCOPE_SAMPLER_H_
+#define ART_RUNTIME_NANOSCOPE_SAMPLER_H_
+
+#include "runtime.h"
+#include <sys/mman.h>
+#include <sys/syscall.h>
+
+#if defined(__ANDROID__)
+#include <linux/perf_event.h>
+#include <sys/ioctl.h>
+#endif
+
+#define SIGTIMER (SIGPROF)
+
+namespace art{
+// Data structures defined to read perf_event counters in sighandler
+struct read_format {
+  uint64_t nr;
+  struct {
+    uint64_t value;
+    uint64_t id;
+  } values[];
+};
+
+const unsigned long PERF_PAGE_SIZE = sysconf(_SC_PAGESIZE);
+
+// Right now we have 3 counters: # of major page faults, # of minor page
+// faults, # of context switches.
+enum CounterType {
+  COUNTER_TYPE_MAJOR_PAGE_FAULTS = 0,
+  COUNTER_TYPE_MINOR_PAGE_FAULTS,
+  COUNTER_TYPE_CONTEXT_SWITCHES,
+  // ===============================
+  COUNTER_TYPE_LIMIT            // total number of counters
+};
+
+enum SampleMode {
+  kSampleDisabled,              // Sampling disabled
+  kSamplePerf,                  // perf_timer mode, use perf_event as sampling timer
+  kSampleCpu                   // cpu_timer mpde, use timer_settime as sampling timer
+};
+
+class NanoscopeSampler{
+public:
+  static void StartSampling(Thread* t, SampleMode sample_mode);
+  static void StopSampling();
+
+private:
+  // Thread with sampling enabled. Use static field so we can access it in signal handler
+  static Thread* sampling_thread_;
+  // Use perf_event to generate sampling signal (perf_timer mode) or use timer_settime (cpu_timer mode) or sampling disabled
+  static SampleMode sample_mode_;
+
+#if defined(__ANDROID__)
+  // Sampling interval in ns
+  static int64_t sample_interval_;
+  // fd of perf_event counter that acts as a timer. Only in perf_timer mode
+  static int perf_timer_fd_;
+  // mmap-ed page used by perf_event counter that acts as a timer. Only in perf_timer mode
+  static struct perf_event_mmap_page* perf_timer_page_;
+
+  // id of timer_settime. Only in cpu_timer mode
+  static timer_t timer_id_;
+
+  // fds of perf_event counters used to gather sampling data.
+  static int sample_fd_[COUNTER_TYPE_LIMIT];
+  // Set up signal handler for SIGPROF
+  static void signal_handler(int sigo ATTRIBUTE_UNUSED, siginfo_t *siginfo ATTRIBUTE_UNUSED, void *ucontext ATTRIBUTE_UNUSED);
+  // Install the correct sighandler
+  static void install_sig_handler();
+
+  // Set up perf_event counters used to gather sampling data
+  static void set_up_sample_counter(CounterType counter_type, int groupfd);
+#endif
+  // Set up the sampling signal timer based on the timer mode
+  static void set_up_timer();
+};
+
+}
+
+#endif  // ART_RUNTIME_NANOSCOPE_SAMPLER_H_

--- a/runtime/quick_exception_handler.cc
+++ b/runtime/quick_exception_handler.cc
@@ -128,7 +128,7 @@ class CatchBlockStackVisitor FINAL : public StackVisitor {
 
       // When an exception is thrown from compiled code, we need to account for the skipped frames in our trace.
       // While walking up the stack to find the corresponding catch block, we also pop our trace frames.
-      GetThread()->TraceEnd(method);
+      GetThread()->TraceEnd();
     }
     return true;  // Continue stack walk.
   }

--- a/runtime/thread-inl.h
+++ b/runtime/thread-inl.h
@@ -89,6 +89,7 @@ inline ThreadState Thread::SetState(ThreadState new_state) {
   union StateAndFlags old_state_and_flags;
   old_state_and_flags.as_int = tls32_.state_and_flags.as_int;
   CHECK_NE(old_state_and_flags.as_struct.state, kRunnable);
+  Thread::Current()->LogStateTransition(static_cast<ThreadState>(old_state_and_flags.as_struct.state), new_state);
   tls32_.state_and_flags.as_struct.state = new_state;
   return static_cast<ThreadState>(old_state_and_flags.as_struct.state);
 }
@@ -161,6 +162,7 @@ inline void Thread::PassActiveSuspendBarriers() {
 inline void Thread::TransitionFromRunnableToSuspended(ThreadState new_state) {
   AssertThreadSuspensionIsAllowable();
   DCHECK_EQ(this, Thread::Current());
+  Thread::Current()->LogStateTransition(kRunnable, new_state);
   // Change to non-runnable state, thereby appearing suspended to the system.
   TransitionToSuspendedAndRunCheckpoints(new_state);
   // Mark the release of the share of the mutator_lock_.
@@ -174,6 +176,7 @@ inline ThreadState Thread::TransitionFromSuspendedToRunnable() {
   old_state_and_flags.as_int = tls32_.state_and_flags.as_int;
   int16_t old_state = old_state_and_flags.as_struct.state;
   DCHECK_NE(static_cast<ThreadState>(old_state), kRunnable);
+  Thread::Current()->LogStateTransition(static_cast<ThreadState>(old_state), kRunnable);
   do {
     Locks::mutator_lock_->AssertNotHeld(this);  // Otherwise we starve GC..
     old_state_and_flags.as_int = tls32_.state_and_flags.as_int;

--- a/runtime/thread.cc
+++ b/runtime/thread.cc
@@ -19,7 +19,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <sys/resource.h>
-#include <sys/time.h>
+
 
 #include <algorithm>
 #include <bitset>
@@ -105,80 +105,23 @@ constexpr size_t kStackOverflowProtectedSize = 4 * kMemoryToolStackGuardSizeScal
 
 static const char* kThreadNameDuringStartup = "<native thread without managed peer>";
 
-// Returns the Generic Timer count. This uses the same timer register used in the compiled code instrumentation.
-uint64_t ALWAYS_INLINE generic_timer_count() {
-  uint64_t t = 0;
-#if defined(__arm__)
-  uint32_t t1, t2;
-  asm volatile("mrrc p15, 1, %0, %1, c14" : "=r"(t1), "=r"(t2));
-  t = t2;
-  t = t << 32 | t1;
-#elif defined(__aarch64__)
-  asm volatile("mrs %0, cntvct_el0" : "=r"(t));
-#elif defined(__i386)
-  unsigned int lo, hi;
-  asm volatile("rdtsc" : "=a"(lo), "=d"(hi));
-  t = ((uint64_t)hi << 32) | lo;
-#endif
-  return t;
-}
-
-#if defined(__i386)
-// This method calculates ticks per second by comparing the built-in clock time to timer count. We call this
-// only once right before converting all trace timestamps, so this will produce inaccurate results if the
-// current frequency differs from the frequency of the clock when the timestamps were recorded. It's preferable
-// to query the frequency directly if available on the CPU architecture.
-uint64_t calculate_ticks_per_second() {
-  struct timeval start_clock_ts;
-  struct timeval end_clock_ts;
-
-  uint64_t start_timer = generic_timer_count();
-  gettimeofday(&start_clock_ts, nullptr);
-
-  usleep(100 * 1000);
-
-  uint64_t end_timer = generic_timer_count();
-  gettimeofday(&end_clock_ts, nullptr);
-
-  uint64_t start_clock_micro = (uint64_t) start_clock_ts.tv_usec;
-  uint64_t end_clock_micro = (uint64_t) end_clock_ts.tv_usec;
-
-  uint64_t timer_ticks = end_timer - start_timer;
-  uint64_t clock_duration_micro = end_clock_micro - start_clock_micro;
-
-  uint64_t ticks_per_second = timer_ticks / clock_duration_micro * 1000 * 1000;
-  return ticks_per_second;
-}
-#endif
-
-// Read the frequency of the generic timer. The register is typically only set during system boot only. So only need to check once.
-uint64_t ALWAYS_INLINE ticks_per_second() {
-  uint64_t t = 0;
-#if defined(__arm__)
-  uint32_t cntfrq;
-  asm volatile("mrc p15, 0, %0, c14, c0, 0" : "=r" (cntfrq));
-  t = cntfrq;
-#elif defined(__aarch64__)
-  uint64_t cntfrq_el0 = 0;
-  asm volatile("mrs %0, cntfrq_el0" : "=r" (cntfrq_el0));
-  t = cntfrq_el0;
-#elif defined(__i386)
-  t = calculate_ticks_per_second();
-#endif
-  return t;
-}
-
-void flush_trace_data(std::string out_path, int64_t* trace_data, int64_t* end)
+void flush_trace_data(std::string out_path, int64_t* trace_data, int64_t* end, uint64_t* timer_data, uint64_t* timer_end, uint64_t* state_data, uint64_t* state_end)
   SHARED_REQUIRES(Locks::mutator_lock_) {
   std::map<ArtMethod*, std::string> pretty_method_cache;
-  std::string out_path_tmp = out_path + ".tmp";
-  std::ofstream out(out_path_tmp, std::ofstream::trunc);
+  std::string out_path_trace = out_path;
+  std::string out_path_timer = out_path + ".timer";
+  std::string out_path_state = out_path + ".state";
+  std::ofstream out_trace_tmp(out_path_trace + ".tmp", std::ofstream::trunc);
+  std::ofstream out_timer_tmp(out_path_timer + ".tmp", std::ofstream::trunc);
+  std::ofstream out_state_tmp(out_path_state + ".tmp", std::ofstream::trunc);
   int64_t* ptr = trace_data;
   uint64_t timer_ticks_per_second = ticks_per_second();
   uint64_t seconds_to_nanoseconds = 1000000000;
 
   uint64_t first_timestamp = 0;
-  if (out.is_open()) {
+  uint64_t* timer_ptr = timer_data;
+  uint64_t* state_ptr = state_data;
+  if (out_trace_tmp.is_open()) {
     while (ptr < end) {
       ArtMethod* method = reinterpret_cast<ArtMethod*>(*ptr++);
       std::string pretty_method;
@@ -200,34 +143,47 @@ void flush_trace_data(std::string out_path, int64_t* trace_data, int64_t* end)
         }
       }
       int64_t timestamp = reinterpret_cast<int64_t>(*ptr++);
-      if (UNLIKELY(first_timestamp == 0)) {
-        first_timestamp = timestamp;
-      }
       timestamp = static_cast<uint64_t>((timestamp - first_timestamp) * (seconds_to_nanoseconds / static_cast<double>(timer_ticks_per_second)));
-      out << timestamp << ":" << pretty_method << "\n";
+      out_trace_tmp << timestamp << ":" << pretty_method << "\n";
     }
-    std::rename(out_path_tmp.c_str(), out_path.c_str());
+    while (timer_ptr < timer_end) {
+      uint64_t timestamp = reinterpret_cast<uint64_t>(*timer_ptr++);
+      timestamp = static_cast<uint64_t>((timestamp - first_timestamp) * (seconds_to_nanoseconds / static_cast<double>(timer_ticks_per_second)));
+      uint64_t signal_time = reinterpret_cast<uint64_t>(*timer_ptr++);
+      uint64_t maj_pf = reinterpret_cast<uint64_t>(*timer_ptr++);
+      uint64_t min_pf = reinterpret_cast<uint64_t>(*timer_ptr++);
+      uint64_t ctx_swtich = reinterpret_cast<uint64_t>(*timer_ptr++);
+      uint64_t bytes = reinterpret_cast<uint64_t>(*timer_ptr++);
+      uint64_t objects = reinterpret_cast<uint64_t>(*timer_ptr++);
+      uint64_t thread_alloc = reinterpret_cast<uint64_t>(*timer_ptr++);
+      uint64_t thread_free = reinterpret_cast<uint64_t>(*timer_ptr++);
+      out_timer_tmp << timestamp << ", " << signal_time << ", " << maj_pf << ", " << min_pf << ", " << ctx_swtich
+      << ", "<< bytes << ", " << objects << ", "<< thread_alloc << ", " << thread_free << "\n";
+    }
+
+    while (state_ptr < state_end) {
+      uint64_t timestamp = reinterpret_cast<uint64_t>(*state_ptr++);
+      timestamp = static_cast<uint64_t>((timestamp - first_timestamp) * (seconds_to_nanoseconds / static_cast<double>(timer_ticks_per_second)));
+      uint64_t old_state = reinterpret_cast<uint64_t>(*state_ptr++);
+      uint64_t new_state = reinterpret_cast<uint64_t>(*state_ptr++);
+      out_state_tmp << timestamp << ", "  << old_state << ", " << new_state << "\n";
+    }
+
+    std::rename((out_path_timer + ".tmp").c_str(), out_path_timer.c_str());
+    std::rename((out_path_state + ".tmp").c_str(), out_path_state.c_str());
+    std::rename((out_path_trace + ".tmp").c_str(), out_path_trace.c_str());
   } else {
     LOG(ERROR) << "Failed to open trace file: " << strerror(errno);
   }
   delete[] trace_data;
+  delete[] timer_data;
+  delete[] state_data;
 }
 
 void Thread::TraceStart(ArtMethod* method) {
-  if (method->is_trace_enabled) {  // Only trace if we haven't blacklisted the ArtMethod. We could use compiler hint to favor blacklisted method performance. However, at time of writing blacklisting is infrequently used.
-    if (LIKELY(tlsPtr_.trace_data_ptr != nullptr)) {  // Only trace if we're on the correct Thread. Use compiler hint to favor the performance of the traced Thread.
-      *tlsPtr_.trace_data_ptr++ = reinterpret_cast<int64_t>(method);
-      *tlsPtr_.trace_data_ptr++ = generic_timer_count();
-    }
-  }
-}
-
-void Thread::TraceEnd(ArtMethod* method) {
-  if (method->is_trace_enabled) {
-    if (LIKELY(tlsPtr_.trace_data_ptr != nullptr)) {
-      *tlsPtr_.trace_data_ptr++ = 0;
-      *tlsPtr_.trace_data_ptr++ = generic_timer_count();
-    }
+  if (LIKELY(tlsPtr_.trace_data_ptr != nullptr)) {  // Only trace if we're on the correct Thread. Use compiler hint to favor the performance of the traced Thread.
+    *tlsPtr_.trace_data_ptr++ = reinterpret_cast<int64_t>(method);
+    *tlsPtr_.trace_data_ptr++ = generic_timer_count();
   }
 }
 
@@ -263,9 +219,13 @@ void Thread::TraceEnd() {
 }
 
 void Thread::StartTracing() {
-  LOG(INFO) << "nanoscope: Trace started.";
-  tlsPtr_.trace_data = new int64_t[40000000];  // Enough room for 10M methods
+  LOG(INFO) << "nanoscope: Trace started, thread " << GetTid();
+  tlsPtr_.trace_data = new int64_t[40000000];   // Enough room for 10M methods
   tlsPtr_.trace_data_ptr = tlsPtr_.trace_data;
+  tlsPtr_.timer_data = new uint64_t[1000000];   // Enough for 20s of sampling
+  tlsPtr_.timer_data_ptr = tlsPtr_.timer_data;
+  tlsPtr_.state_data = new uint64_t[1000000];
+  tlsPtr_.state_data_ptr = tlsPtr_.state_data;
 }
 
 void Thread::StopTracing(std::string out_path) {
@@ -275,17 +235,21 @@ void Thread::StopTracing(std::string out_path) {
 
   char* dir = dirname(strdup(out_path.c_str()));
   std::string mkdirs = "mkdir -p " + std::string(dir);
-  system(mkdirs.c_str());
+  int ret = system(mkdirs.c_str());
+  CHECK(ret != -1);
 
   LOG(INFO) << "nanoscope: Flushing trace data to: " << out_path;
-
   if (kIsDebugBuild) {
-    flush_trace_data(out_path, tlsPtr_.trace_data, tlsPtr_.trace_data_ptr);
+    flush_trace_data(out_path, tlsPtr_.trace_data, tlsPtr_.trace_data_ptr, tlsPtr_.timer_data,tlsPtr_.timer_data_ptr, tlsPtr_.state_data, tlsPtr_.state_data_ptr);
   } else {
-    new std::thread(flush_trace_data, out_path, tlsPtr_.trace_data, tlsPtr_.trace_data_ptr);
+    new std::thread(flush_trace_data, out_path, tlsPtr_.trace_data, tlsPtr_.trace_data_ptr, tlsPtr_.timer_data, tlsPtr_.timer_data_ptr, tlsPtr_.state_data, tlsPtr_.state_data_ptr);
   }
   tlsPtr_.trace_data = nullptr;
   tlsPtr_.trace_data_ptr = nullptr;
+  tlsPtr_.timer_data = nullptr;
+  tlsPtr_.timer_data_ptr = nullptr;
+  tlsPtr_.state_data = nullptr;
+  tlsPtr_.state_data_ptr = nullptr;
 
   // A race condition exists if we stop tracing from a different Thread. In Thread::TraceStart and Thread::TraceEnd
   // we may end up incrementing and dereferencing trace_data_ptr after we've nulled it out above. If we hit this race
@@ -298,8 +262,49 @@ void Thread::StopTracing(std::string out_path) {
     usleep(1000 * 100);
     tlsPtr_.trace_data = nullptr;
     tlsPtr_.trace_data_ptr = nullptr;
+    tlsPtr_.timer_data = nullptr;
+    tlsPtr_.timer_data_ptr = nullptr;
+    tlsPtr_.state_data = nullptr;
+    tlsPtr_.state_data_ptr = nullptr;
   }
 }
+
+void Thread::TimerHandler(uint64_t time, uint64_t maj_pf, uint64_t min_pf, uint64_t ctx_swtich){
+  if(tlsPtr_.timer_data_ptr != nullptr){
+    *tlsPtr_.timer_data_ptr ++ = generic_timer_count();
+    *tlsPtr_.timer_data_ptr ++ = time;
+    *tlsPtr_.timer_data_ptr ++ = maj_pf;
+    *tlsPtr_.timer_data_ptr ++ = min_pf;
+    *tlsPtr_.timer_data_ptr ++ = ctx_swtich;
+
+    // Get allocation info
+    RuntimeStats* global_stats = Runtime::Current()->GetStats();
+    if(global_stats -> allocated_bytes > global_stats->freed_bytes){
+      *tlsPtr_.timer_data_ptr ++ = global_stats->allocated_bytes - global_stats->freed_bytes;
+    } else {
+      *tlsPtr_.timer_data_ptr ++ = 0;
+    }
+    if(global_stats->allocated_objects > global_stats->freed_objects){
+      *tlsPtr_.timer_data_ptr ++ = global_stats->allocated_objects - global_stats->freed_objects;
+    } else {
+      *tlsPtr_.timer_data_ptr ++ = 0;
+    }
+    RuntimeStats* thread_stats = GetStats();
+    *tlsPtr_.timer_data_ptr ++ = thread_stats->allocated_bytes;
+    *tlsPtr_.timer_data_ptr ++ = thread_stats->freed_bytes;
+  } else {
+    LOG(INFO) << "nanoscope: wrong thread" << "\n";
+  }
+}
+
+void Thread::LogStateTransition(ThreadState old_state, ThreadState new_state){
+  if(tlsPtr_.state_data_ptr != nullptr){
+    *tlsPtr_.state_data_ptr ++ = generic_timer_count();
+    *tlsPtr_.state_data_ptr ++ = old_state;
+    *tlsPtr_.state_data_ptr ++ = new_state;
+  }
+}
+
 
 void Thread::InitCardTable() {
   tlsPtr_.card_table = Runtime::Current()->GetHeap()->GetCardTable()->GetBiasedBegin();

--- a/runtime/utils.cc
+++ b/runtime/utils.cc
@@ -22,6 +22,7 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include <memory>
 
@@ -1899,5 +1900,76 @@ void SleepForever() {
     usleep(1000000);
   }
 }
+
+// Returns the Generic Timer count. This uses the same timer register used in the compiled code instrumentation.
+uint64_t ALWAYS_INLINE generic_timer_count() {
+  uint64_t t = 0;
+#if defined(__arm__)
+  uint32_t t1, t2;
+  asm volatile("mrrc p15, 1, %0, %1, c14" : "=r"(t1), "=r"(t2));
+  t = t2;
+  t = t << 32 | t1;
+#elif defined(__aarch64__)
+  asm volatile("mrs %0, cntvct_el0" : "=r"(t));
+#elif defined(__i386)
+  unsigned int lo, hi;
+  asm volatile("rdtsc" : "=a"(lo), "=d"(hi));
+  t = ((uint64_t)hi << 32) | lo;
+#endif
+  return t;
+}
+
+uint64_t ALWAYS_INLINE generic_timer_ts() {
+  uint64_t ts = generic_timer_count();
+  uint64_t timer_ticks_per_second = ticks_per_second();
+  uint64_t seconds_to_nanoseconds = 1000000000;
+  return static_cast<uint64_t>(ts * (seconds_to_nanoseconds / static_cast<double>(timer_ticks_per_second)));
+}
+
+#if defined(__i386)
+// This method calculates ticks per second by comparing the built-in clock time to timer count. We call this
+// only once right before converting all trace timestamps, so this will produce inaccurate results if the
+// current frequency differs from the frequency of the clock when the timestamps were recorded. It's preferable
+// to query the frequency directly if available on the CPU architecture.
+uint64_t calculate_ticks_per_second() {
+  struct timeval start_clock_ts;
+  struct timeval end_clock_ts;
+
+  uint64_t start_timer = generic_timer_count();
+  gettimeofday(&start_clock_ts, nullptr);
+
+  usleep(100 * 1000);
+
+  uint64_t end_timer = generic_timer_count();
+  gettimeofday(&end_clock_ts, nullptr);
+
+  uint64_t start_clock_micro = (uint64_t) start_clock_ts.tv_usec;
+  uint64_t end_clock_micro = (uint64_t) end_clock_ts.tv_usec;
+
+  uint64_t timer_ticks = end_timer - start_timer;
+  uint64_t clock_duration_micro = end_clock_micro - start_clock_micro;
+
+  uint64_t ticks_per_second = timer_ticks / clock_duration_micro * 1000 * 1000;
+  return ticks_per_second;
+}
+#endif
+
+// Read the frequency of the generic timer. The register is typically only set during system boot only. So only need to check once.
+uint64_t ALWAYS_INLINE ticks_per_second() {
+  uint64_t t = 0;
+#if defined(__arm__)
+  uint32_t cntfrq;
+  asm volatile("mrc p15, 0, %0, c14, c0, 0" : "=r" (cntfrq));
+  t = cntfrq;
+#elif defined(__aarch64__)
+  uint64_t cntfrq_el0 = 0;
+  asm volatile("mrs %0, cntfrq_el0" : "=r" (cntfrq_el0));
+  t = cntfrq_el0;
+#elif defined(__i386)
+  t = calculate_ticks_per_second();
+#endif
+  return t;
+}
+
 
 }  // namespace art

--- a/runtime/utils.h
+++ b/runtime/utils.h
@@ -416,6 +416,11 @@ inline void FlushInstructionCache(char* begin, char* end) {
 #endif
 }
 
+uint64_t ALWAYS_INLINE generic_timer_count();
+uint64_t ALWAYS_INLINE generic_timer_ts();
+
+uint64_t ALWAYS_INLINE ticks_per_second();
+
 }  // namespace art
 
 #endif  // ART_RUNTIME_UTILS_H_


### PR DESCRIPTION
# Major changes
* Add sampling support
* Add tracing for native methods
* Add tracing of VM thread state transition

## Sampling support
These new changes add sampling support to nanoscope. Currently supports two sampling mode:
* `perf_timer` mode uses `perf_event_open` to generate sampling signals
* `cpu_timer` mode uses `timer_settime` to generate sampling signals

### Usage
Sampling only works on real device. For some of the devices, may need to change the `kernel.perf_event_paranoid` setting:
```adb shell "echo -1 >/proc/sys/kernel/perf_event_paranoid"```

`adb shell setprop dev.nanoscope com.example:data.txt:perf_timer`  starts tracing with sampling in `perf_timer` mode

`adb shell setprop dev.nanoscope com.example:data.txt:cpu_timer` starts tracing with sampling in `cpu_timer` mode

`adb shell setprop dev.nanoscope com.example:data.txt` starts tracing without sampling

Default sampling interval is 1ms. In `perf_timer` sampling is based on wall clock time and in `cpu_timer` sampling is based on cpu time.

### Log files
In additional to `data.ext` file, we will also be generating two additional files: `data.ext.timer` which contains all sample data and `data.ext.state` which contains state transition trace. Those two files will be consumed by the new Nanoscope Visualizer. If sampling is not enabled, those two files will be empty.

`data.ext.timer` is organized in the following format:
Each row represents a sample, each sample is in the format of:
```wall clock ts, cpu ts, # of major page faults, # of minor page faults, context switches, process memory usage (bytes), process memory usage (objects), memory ever allocated by traced thread (bytes), memory ever freed by traced thread```