### PR TITLE
Minor fixes, refinements, and formatting improvements.

### DIFF
--- a/runtime/nanoscope_sampler.h
+++ b/runtime/nanoscope_sampler.h
@@ -29,17 +29,6 @@
 #define SIGTIMER (SIGPROF)
 
 namespace art{
-// Data structures defined to read perf_event counters in sighandler
-struct read_format {
-  uint64_t nr;
-  struct {
-    uint64_t value;
-    uint64_t id;
-  } values[];
-};
-
-const unsigned long PERF_PAGE_SIZE = sysconf(_SC_PAGESIZE);
-
 // Right now we have 3 counters: # of major page faults, # of minor page
 // faults, # of context switches.
 enum CounterType {
@@ -49,6 +38,17 @@ enum CounterType {
   // ===============================
   COUNTER_TYPE_LIMIT            // total number of counters
 };
+
+// Data structures defined to read perf_event counters in sighandler
+struct read_format {
+  uint64_t nr;
+  struct {
+    uint64_t value;
+    uint64_t id;
+  } values[COUNTER_TYPE_LIMIT];
+};
+
+const unsigned long PERF_PAGE_SIZE = sysconf(_SC_PAGESIZE);
 
 enum SampleMode {
   kSampleDisabled,              // Sampling disabled


### PR DESCRIPTION
There are some formatting improvements here with respect to indentation and curlies around conditionals. I have also fixed a problem with **cpu_mode** incorrectly accessing structures used only in **perf_mode**. Finally, I have made reading sample values more robust (and avoided allocating a large array buffer on the stack).